### PR TITLE
Provide ability to print joins for the inherited tables in FROM clause instead of WHERE

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/descriptors/DescriptorQueryManager.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/descriptors/DescriptorQueryManager.java
@@ -105,6 +105,7 @@ public class DescriptorQueryManager implements Cloneable, Serializable {
     protected boolean hasCustomMultipleTableJoinExpression;
     protected String additionalCriteria;
     protected transient Expression additionalJoinExpression;
+    protected transient Expression additionalJoinExpressionWithoutMultiTableJoins;
     protected transient Expression multipleTableJoinExpression;
     protected Map<String, List<DatabaseQuery>> queries;
     protected transient Map<DatabaseTable, Expression> tablesJoinExpressions;
@@ -349,6 +350,15 @@ public class DescriptorQueryManager implements Cloneable, Serializable {
     public Expression getAdditionalJoinExpression() {
         return additionalJoinExpression;
     }
+
+    // cuba begin
+    /**
+     *  Additional expression to add to the where clause without the multitable inheritance expression
+     */
+    public Expression getAdditionalJoinExpressionWithoutMultiTableJoins() {
+        return additionalJoinExpressionWithoutMultiTableJoins;
+    }
+    // cuba end
 
     /**
      * ADVANCED:
@@ -860,6 +870,11 @@ public class DescriptorQueryManager implements Cloneable, Serializable {
         }
 
         if (getMultipleTableJoinExpression() != null) {
+            // cuba begin
+            // Store original expression to use if the inheritance joins are generated in the FROM clause
+            additionalJoinExpressionWithoutMultiTableJoins = getAdditionalJoinExpression();
+            // cuba end
+
             // Combine new multiple table expression to additional join expression
             setAdditionalJoinExpression(getMultipleTableJoinExpression().and(getAdditionalJoinExpression()));
         }
@@ -962,6 +977,9 @@ public class DescriptorQueryManager implements Cloneable, Serializable {
 
             updatePropertyParameterExpression(selectionCriteria);
             additionalJoinExpression = selectionCriteria.and(additionalJoinExpression);
+            // cuba begin
+            additionalJoinExpressionWithoutMultiTableJoins = selectionCriteria.and(additionalJoinExpressionWithoutMultiTableJoins);
+            // cuba end
         }
 
         if (additionalJoinExpression != null) {
@@ -970,6 +988,14 @@ public class DescriptorQueryManager implements Cloneable, Serializable {
             // expression builder.
             additionalJoinExpression = additionalJoinExpression.rebuildOn(new ExpressionBuilder());
         }
+
+        // cuba begin
+        // rebuild like the previous one
+        if( additionalJoinExpressionWithoutMultiTableJoins != null) {
+            additionalJoinExpressionWithoutMultiTableJoins =
+                    additionalJoinExpressionWithoutMultiTableJoins.rebuildOn(new ExpressionBuilder());
+        }
+        // cuba end
     }
 
     /**

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/expressions/ExpressionBuilder.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/expressions/ExpressionBuilder.java
@@ -14,10 +14,6 @@
 //     Oracle - initial API and implementation from Oracle TopLink
 package org.eclipse.persistence.expressions;
 
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.util.Map;
-
 import org.eclipse.persistence.descriptors.ClassDescriptor;
 import org.eclipse.persistence.exceptions.QueryException;
 import org.eclipse.persistence.history.AsOfClause;
@@ -30,6 +26,10 @@ import org.eclipse.persistence.internal.sessions.AbstractRecord;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.queries.DatabaseQuery;
 import org.eclipse.persistence.queries.ReadQuery;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.util.Map;
 
 /**
  * <P>
@@ -294,7 +294,13 @@ public class ExpressionBuilder extends ObjectExpression {
                 throw QueryException.noExpressionBuilderFound(this);
             }
             if (!this.wasAdditionJoinCriteriaUsed) {
-                criteria = getDescriptor().getQueryManager().getAdditionalJoinExpression();
+                // cuba begin
+                if (getSession().getPlatform().shouldPrintInheritanceTableJoinsInFromClause()) {
+                    criteria = getDescriptor().getQueryManager().getAdditionalJoinExpressionWithoutMultiTableJoins();
+                } else {
+                    criteria = getDescriptor().getQueryManager().getAdditionalJoinExpression();
+                }
+                // cuba end
                 if (criteria != null) {
                     criteria = twist(criteria, this);
                 }

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/databaseaccess/DatabasePlatform.java
@@ -176,6 +176,11 @@ public class DatabasePlatform extends DatasourcePlatform {
     /** Allow configuration option to use Where clause joining or From clause joining. **/
     protected Boolean printInnerJoinInWhereClause;
 
+    // cuba begin
+    /** **/
+    protected Boolean printInheritanceTableJoinsInFromClause;
+    // cuba end
+
     /** Allow for the code that is used for preparing cursored outs for a storedprocedure to be settable. **/
     protected int cursorCode;
 
@@ -2094,6 +2099,20 @@ public class DatabasePlatform extends DatasourcePlatform {
         this.printInnerJoinInWhereClause = Boolean.valueOf(printInnerJoinInWhereClause);
     }
 
+    // cuba begin
+
+    /**
+     * Changes the mechanism to print joins for the inherited tables. If true joins will be printed in the FROM
+     * clause using {@link org.eclipse.persistence.internal.expressions.OuterJoinExpressionHolder}. Only works for
+     * straight cases like this queue: select d from df$Doc d. This means that this parameter isn't used in the batch loading fields
+     * for the fetch plan for example.
+     *
+     */
+    public void setPrintInheritanceTableJoinsInFromClause(boolean printInheritanceTableJoinsInFromClause) {
+        this.printInheritanceTableJoinsInFromClause = printInheritanceTableJoinsInFromClause;
+    }
+    // cuba end
+
     public void setUsesStringBinding(boolean aBool) {
         usesStringBinding = aBool;
     }
@@ -2227,6 +2246,19 @@ public class DatabasePlatform extends DatasourcePlatform {
         }
         return this.printInnerJoinInWhereClause;
     }
+
+    // cuba begin
+    /**
+     * If we need to print joins for the inherited tables. If true joins will be printed in the FROM
+     * clause using {@link org.eclipse.persistence.internal.expressions.OuterJoinExpressionHolder}. Only works for
+     * straight cases like this queue: select d from df$Doc d. This means that this parameter isn't used in the batch loading fields
+     * for the fetch plan for example.
+     *
+     */
+    public boolean shouldPrintInheritanceTableJoinsInFromClause() {
+        return printInheritanceTableJoinsInFromClause;
+    }
+    // cuba end
 
     /**
      * Used for stored procedure creation: Some platforms want to print prefix for INPUT arguments BEFORE NAME. If wanted, override and return true.

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/SQLSelectStatement.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/expressions/SQLSelectStatement.java
@@ -1188,6 +1188,12 @@ public class SQLSelectStatement extends SQLStatement {
         return outerJoinExpressionHolders;
     }
 
+    public Integer addOuterJoinExpressionsHolders(ObjectExpression joinExpression, Expression outerJoinedMappingCriteria,
+            Map<DatabaseTable, Expression> outerJoinedAdditionalJoinCriteria, ClassDescriptor descriptor) {
+        return addOuterJoinExpressionsHolders(joinExpression, outerJoinedMappingCriteria, outerJoinedAdditionalJoinCriteria, descriptor, false);
+    }
+
+    // cuba begin  (useInnerJoinForAdditionalJoinCriteria parameter added)
     /**
      * INTERNAL:
      * Used by ExpressionBuilder and QueryKeyExpression normalization to create a standard outerjoin.
@@ -1195,18 +1201,22 @@ public class SQLSelectStatement extends SQLStatement {
      * @param outerJoinedMappingCriteria - used for querykey mapping expressions
      * @param outerJoinedAdditionalJoinCriteria - additional tables/expressions to join.  Usually for multitableInheritance join expressions
      * @param descriptor - descriptor to use if this is for reading in subclasses in one query.
+     * @param useInnerJoinForAdditionalJoinCriteria - used to use inner joins instead of left outer joins for tables in the 'outerJoinedAdditionalJoinCriteria' param
      * @return
      */
     public Integer addOuterJoinExpressionsHolders(ObjectExpression joinExpression, Expression outerJoinedMappingCriteria,
-            Map<DatabaseTable, Expression> outerJoinedAdditionalJoinCriteria, ClassDescriptor descriptor) {
+                                                  Map<DatabaseTable, Expression> outerJoinedAdditionalJoinCriteria,
+                                                  ClassDescriptor descriptor,
+                                                  boolean useInnerJoinForAdditionalJoinCriteria) {
 
         int index = getOuterJoinExpressionsHolders().size();
         OuterJoinExpressionHolder holder = new OuterJoinExpressionHolder(this, joinExpression, outerJoinedMappingCriteria,
-                outerJoinedAdditionalJoinCriteria, descriptor);
+                outerJoinedAdditionalJoinCriteria, descriptor, useInnerJoinForAdditionalJoinCriteria);
 
         getOuterJoinExpressionsHolders().add(holder);
         return index;
     }
+    // cuba end
 
     /**
      * INTERNAL:

--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/internal/queries/ExpressionQueryMechanism.java
@@ -20,34 +20,30 @@
 //       - Github#93: Bug with bulk update processing involving version field update parameter
 package org.eclipse.persistence.internal.queries;
 
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
+import org.eclipse.persistence.descriptors.ClassDescriptor;
+import org.eclipse.persistence.descriptors.DescriptorQueryManager;
+import org.eclipse.persistence.descriptors.InheritancePolicy;
+import org.eclipse.persistence.exceptions.DatabaseException;
+import org.eclipse.persistence.exceptions.QueryException;
+import org.eclipse.persistence.expressions.Expression;
+import org.eclipse.persistence.expressions.ExpressionBuilder;
+import org.eclipse.persistence.internal.databaseaccess.DatabaseCall;
 import org.eclipse.persistence.internal.databaseaccess.DatasourceCall;
 import org.eclipse.persistence.internal.databaseaccess.DatasourcePlatform;
 import org.eclipse.persistence.internal.descriptors.OptimisticLockingPolicy;
+import org.eclipse.persistence.internal.expressions.*;
 import org.eclipse.persistence.internal.helper.*;
 import org.eclipse.persistence.internal.identitymaps.CacheKey;
-import org.eclipse.persistence.internal.expressions.*;
-import org.eclipse.persistence.expressions.*;
-import org.eclipse.persistence.logging.SessionLog;
-import org.eclipse.persistence.mappings.AggregateCollectionMapping;
-import org.eclipse.persistence.mappings.DatabaseMapping;
-import org.eclipse.persistence.mappings.DirectCollectionMapping;
-import org.eclipse.persistence.mappings.ForeignReferenceMapping;
-import org.eclipse.persistence.mappings.ManyToManyMapping;
-import org.eclipse.persistence.mappings.RelationTableMechanism;
-import org.eclipse.persistence.exceptions.*;
-import org.eclipse.persistence.mappings.OneToOneMapping;
-import org.eclipse.persistence.queries.*;
-import org.eclipse.persistence.descriptors.InheritancePolicy;
-import org.eclipse.persistence.descriptors.DescriptorQueryManager;
 import org.eclipse.persistence.internal.sessions.AbstractRecord;
-import org.eclipse.persistence.internal.sessions.UnitOfWorkImpl;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
-import org.eclipse.persistence.descriptors.ClassDescriptor;
-import org.eclipse.persistence.internal.databaseaccess.DatabaseCall;
+import org.eclipse.persistence.internal.sessions.UnitOfWorkImpl;
+import org.eclipse.persistence.logging.SessionLog;
+import org.eclipse.persistence.mappings.*;
+import org.eclipse.persistence.queries.*;
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * <p><b>Purpose</b>:
@@ -161,12 +157,19 @@ public class ExpressionQueryMechanism extends StatementQueryMechanism {
             DescriptorQueryManager queryManager = getDescriptor().getQueryManager();
             Expression additionalJoin;
             if (shouldUseAdditionalJoinExpression) {
-                additionalJoin = queryManager.getAdditionalJoinExpression();
+                // cuba begin
+                if (getSession().getPlatform().shouldPrintInheritanceTableJoinsInFromClause()) {
+                    additionalJoin = queryManager.getAdditionalJoinExpressionWithoutMultiTableJoins();
+                } else {
+                    additionalJoin = queryManager.getAdditionalJoinExpression();
+                }
+                // cuba end
             } else {
                 additionalJoin = queryManager.getMultipleTableJoinExpression();
-                if (additionalJoin == null) {
-                    return expression;
-                }
+            }
+
+            if (additionalJoin == null) {
+                return expression;
             }
 
             // If there's an expression, then we know we'll have to rebuild anyway, so don't clone.
@@ -208,6 +211,13 @@ public class ExpressionQueryMechanism extends StatementQueryMechanism {
         selectStatement.setLockingClause(query.getLockingClause());
         selectStatement.setDistinctState(query.getDistinctState());
         selectStatement.setTables((Vector)getDescriptor().getTables().clone());
+
+        // cuba begin
+        if (getSession().getPlatform().shouldPrintInheritanceTableJoinsInFromClause()) {
+            addInheritanceTablesJoinsInFromClause(selectStatement);
+        }
+        // cuba end
+
         selectStatement.setWhereClause(buildBaseSelectionCriteria(isSubSelect, clonedExpressions, shouldUseAdditionalJoinExpression));
         //make sure we use the cloned builder and make sure we get the builder from the query if we have set the type.
         // If we use the expression builder and there are parallel builders and the query builder is on the 'right'
@@ -243,6 +253,39 @@ public class ExpressionQueryMechanism extends StatementQueryMechanism {
         selectStatement.setTranslationRow(getTranslationRow());
         return selectStatement;
     }
+
+    // cuba begin
+    protected void addInheritanceTablesJoinsInFromClause(SQLSelectStatement selectStatement) {
+        Vector<DatabaseTable> tablesInCurrentStatement = (Vector<DatabaseTable>) selectStatement.getTables();
+
+        DescriptorQueryManager queryManager = getDescriptor().getQueryManager();
+        ClassDescriptor descriptor = queryManager.getDescriptor();
+
+        if (descriptor.hasInheritance() && !descriptor.equals(descriptor.getRootDescriptor())) {
+            ClassDescriptor rootDescriptor = descriptor.getRootDescriptor();
+            Map<DatabaseTable, Expression> childrenTablesJoinExpressions = rootDescriptor.getInheritancePolicy()
+                    .getChildrenTablesJoinExpressions();
+
+            if(childrenTablesJoinExpressions == null || childrenTablesJoinExpressions.isEmpty())
+                // Inheritance type is not JOINED
+                return;
+
+            // Adding joins from the root entity but only for the tables used in the current statement
+            HashMap<DatabaseTable, Expression> joinExpressionsMap = new HashMap<>(childrenTablesJoinExpressions);
+            for (Iterator<Map.Entry<DatabaseTable, Expression>> it = joinExpressionsMap.entrySet().iterator(); it.hasNext(); ) {
+                DatabaseTable databaseTable = it.next().getKey();
+                if (!tablesInCurrentStatement.contains(databaseTable)) {
+                    it.remove();
+                }
+            }
+
+            if(!joinExpressionsMap.isEmpty()) {
+                selectStatement.addOuterJoinExpressionsHolders(null, null,
+                        joinExpressionsMap, getDescriptor().getRootDescriptor(), true);
+            }
+        }
+    }
+    // cuba end
 
     /**
      * Return the appropriate select statement containing the fields in the table.


### PR DESCRIPTION
Eclipselink by default adds JOINS for the inherited entities in the WHERE clause which can cause performance problems on postgresql database.

This case could be illustrated by this entities:
```java
@Table(name = "TEST_ROOT_ENTITY")
@Entity(name = "test$RootEntity")
@Inheritance(strategy = InheritanceType.JOINED)
@DiscriminatorColumn(name = "ENTITY_TYPE", discriminatorType = DiscriminatorType.INTEGER)
@DiscriminatorValue("0")
public class RootEntity extends StandardEntity {
@JoinColumn(name = "ROOT_REF_ENTITY_ID")
    @ManyToOne(fetch = FetchType.LAZY)
    private RootReferenceEntity rootReferenceEntity;
    ....
}
```
```java
@Table(name = "TEST_CHILD_ENTITY")
@Entity(name = "test$ChildEntity")
@PrimaryKeyJoinColumn(name = "CHILD_ID", referencedColumnName = "ID")
@DiscriminatorValue("1")
public class ChildEntity extends RootEntity {
    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "REF_ENTITY_ID")
    protected ReferenceEntity referenceEntity;
    ....
}
```
```java
@Table(name = "TEST_ANOTHER_CHILD")
@Entity(name = "test_AnotherChild")
@PrimaryKeyJoinColumn(name = "CHILD_ID", referencedColumnName = "ID")
@DiscriminatorValue("2")
public class AnotherChild extends ChildEntity {
    ....
}
```

The query is: `select e from test$ChildEntity e`

The query is using such hints (FetchGroup):

e.referenceEntity - eclipselink.left-join-fetch
e.rootReferenceEntity - eclipselink.left-join-fetch

Generated sql :
```sql
SELECT t1.ID AS a1, t1.ENTITY_TYPE AS a2, t1.DELETE_TS AS a3, t1.DELETED_BY AS a4, t1.ROOT_ATTR AS a5, t1.VERSION AS a6, t1.ROOT_REF_ENTITY_ID AS a7, t2.REF_ENTITY_ID AS a8, t0.ID AS a9, t0.DELETE_TS AS a10, t0.DELETED_BY AS a11, t0.NAME_ AS a12, t0.VERSION AS a13, t4.ID AS a14, t4.DELETE_TS AS a15, t4.DELETED_BY AS a16, t4.VERSION AS a17 
FROM TEST_ROOT_ENTITY t1 
     LEFT OUTER JOIN TEST_ANOTHER_CHILD t3 ON (t3.CHILD_ID = t1.ID) 
     LEFT OUTER JOIN TEST_ROOT_REFERENCE_ENTITY t4 ON (t4.ID = t1.ROOT_REF_ENTITY_ID)
,TEST_CHILD_ENTITY t2 
     LEFT OUTER JOIN TEST_REFERENCE_ENTITY t0 ON (t0.ID = t2.REF_ENTITY_ID) 
WHERE (((t1.DELETE_TS IS NULL) AND (t2.CHILD_ID = t1.ID)) AND (t1.ENTITY_TYPE IN (?, ?))) LIMIT ? OFFSET ?
```

The problem is that the join with the TEST_CHILD_ENTITY (t2) is located in the WHERE clause (AND (t2.CHILD_ID = t1.ID)). In this simple query this doesn't affect the performance but in case of many joined fields this could be a problem for example on the PostgreSQL database (i.e. if joins count is more than join_collapse_limit property).

To overcome this problem such workaround is provided:

- Added parameter 'printInheritanceTableJoinsInFromClause' in the DatabasePlatform to switch on\off this functionality.
- If this parameter set to true then the joins to the child entities will be printed in the FROM clause (traditional inner join). This happens in the ExpressionQueryMechanism, joins are added as the OuterJoinExpressionHolder objects. Joins are added for every table in the inheritance hierarchy used in the current query
- To exlude such joins from the WHERE clause, DescriptorQueryManager class was modified to store the additionalJoinExpression without the expressions related to the multitable inheritance.

Using this parameter request from the example will be: 

```sql
SELECT t1.ID AS a1, t1.ENTITY_TYPE AS a2, t1.DELETE_TS AS a3, t1.DELETED_BY AS a4, t1.ROOT_ATTR AS a5, t1.VERSION AS a6, t1.ROOT_REF_ENTITY_ID AS a7, t2.REF_ENTITY_ID AS a8, t0.ID AS a9, t0.DELETE_TS AS a10, t0.DELETED_BY AS a11, t0.NAME_ AS a12, t0.VERSION AS a13, t4.ID AS a14, t4.DELETE_TS AS a15, t4.DELETED_BY AS a16, t4.VERSION AS a17 
FROM TEST_ROOT_ENTITY t1 
join t TEST_CHILD_ENTITY t2
     LEFT OUTER JOIN TEST_ANOTHER_CHILD t3 ON (t3.CHILD_ID = t1.ID) 
     LEFT OUTER JOIN TEST_ROOT_REFERENCE_ENTITY t4 ON (t4.ID = t1.ROOT_REF_ENTITY_ID)
     LEFT OUTER JOIN TEST_REFERENCE_ENTITY t0 ON (t0.ID = t2.REF_ENTITY_ID) 
WHERE ((t1.DELETE_TS IS NULL) AND (t1.ENTITY_TYPE IN (?, ?))) LIMIT ? OFFSET ?
```


